### PR TITLE
Ability to get all groups

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -32,6 +32,8 @@ func (e *Entity) Find() []interface{} {
 	entities := []Entity{}
 	if e.Name != "" {
 		db.Where("name = ?", e.Name).Find(&entities)
+	} else {
+		db.Find(&entities)
 	}
 
 	list := make([]interface{}, len(entities))


### PR DESCRIPTION
When no data is provided to a group.find we will retrieve them all. 
Example query:
```
nats-request group.find '{}' 
```